### PR TITLE
Link to full topic URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,47 +73,47 @@
 </thead>
 <tbody>
 <tr>
-<td><a href="01-motivation/1-motivation.adoc">Motivation</a></td>
+<td><a href="https://github.com/OSAS/tos-repository/blob/master/01-motivation/1-motivation.adoc">Motivation</a></td>
 <td>Why teach and learn open source software? The WHY for both teachers and students</td>
 </tr>
 <tr>
-<td><a href="02-oss_fundamentals/1-fundamentals.adoc">OSS Fundamentals</a></td>
+<td><a href="https://github.com/OSAS/tos-repository/blob/master/02-oss_fundamentals/1-fundamentals.adoc">OSS Fundamentals</a></td>
 <td>Overview, that there is a community, initial copyright and licensing explanations, what kinds of things do they do, how do the many pieces fit together</td>
 </tr>
 <tr>
-<td><a href="03-legal_aspects/1-legal.adoc">Legal Aspects</a></td>
+<td><a href="https://github.com/OSAS/tos-repository/blob/master/03-legal_aspects/1-legal.adoc">Legal Aspects</a></td>
 <td>Intellectual property law and copyright licensing underpinnings, and how it supports the open source effort</td>
 </tr>
 <tr>
-<td><a href="04-history/1-history.adoc">History</a></td>
+<td><a href="https://github.com/OSAS/tos-repository/blob/master/04-history/1-history.adoc">History</a></td>
 <td>How FOSS came to be, the context that it was born in, influential people and parties</td>
 </tr>
 <tr>
-<td><a href="05-tools/1-tools.adoc">Tools</a></td>
+<td><a href="https://github.com/OSAS/tos-repository/blob/master/05-tools/1-tools.adoc">Tools</a></td>
 <td>asd</td>
 </tr>
 <tr>
-<td><a href="06-getting_the_code/1-get.adoc">Getting the Code</a></td>
+<td><a href="https://github.com/OSAS/tos-repository/blob/master/06-getting_the_code/1-get.adoc">Getting the Code</a></td>
 <td>asd</td>
 </tr>
 <tr>
-<td><a href="07-building_and_running_the_code/1-build.adoc">Building and Running the Code</a></td>
+<td><a href="https://github.com/OSAS/tos-repository/blob/master/07-building_and_running_the_code/1-build.adoc">Building and Running the Code</a></td>
 <td>asd</td>
 </tr>
 <tr>
-<td><a href="08-debugging_the_code/1-debug.adoc">Debugging the Code</a></td>
+<td><a href="https://github.com/OSAS/tos-repository/blob/master/08-debugging_the_code/1-debug.adoc">Debugging the Code</a></td>
 <td>asd</td>
 </tr>
 <tr>
-<td><a href="09-contributing_the_code/1-contribute.adoc">Contributing the Code</a></td>
+<td><a href="https://github.com/OSAS/tos-repository/blob/master/09-contributing_the_code/1-contribute.adoc">Contributing the Code</a></td>
 <td>asd</td>
 </tr>
 <tr>
-<td><a href="10-community_philosophy/1-philosophy.adoc">Community Philosophy</a></td>
+<td><a href="https://github.com/OSAS/tos-repository/blob/master/10-community_philosophy/1-philosophy.adoc">Community Philosophy</a></td>
 <td>asd</td>
 </tr>
 <tr>
-<td><a href="11-communication/1-communication.adoc">Communication</a></td>
+<td><a href="https://github.com/OSAS/tos-repository/blob/master/11-communication/1-communication.adoc">Communication</a></td>
 <td>asd</td>
 </tr>
 </tbody>


### PR DESCRIPTION
Links were formerly pointing to “local” / “relative” .adoc documents.
This gh-pages branch does not know the relative documents and therefore
needs to link to the full URL’s
